### PR TITLE
modify kafka healthCheck logic

### DIFF
--- a/ApiServerSample/pom.xml
+++ b/ApiServerSample/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>me.phoboslabs.illuminati</groupId>
             <artifactId>illuminati-processor</artifactId>
-            <version>0.9.9.32</version>
+            <version>0.9.9.35</version>
             <scope>compile</scope>
         </dependency>
 

--- a/ApiServerSample/src/main/resources/illuminati-local.yml
+++ b/ApiServerSample/src/main/resources/illuminati-local.yml
@@ -17,10 +17,10 @@
 #kafka
 broker: kafka
 clusterList: 127.0.0.1:9092
-topic: test
+topic: illuminati-test-topic
 isAsync: true
 isCompression: true
-compressionType: zstd
+compressionType: gzip
 performance: 1
 parentModuleName: apisample
 samplingRate: 100

--- a/illuminati/illuminati-processor/pom.xml
+++ b/illuminati/illuminati-processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.phoboslabs.illuminati</groupId>
     <artifactId>illuminati-processor</artifactId>
-    <version>0.9.9.33</version>
+    <version>0.9.9.35</version>
     <packaging>jar</packaging>
 
     <name>illuminati-processor</name>

--- a/illuminati/illuminati-processor/src/main/java/me/phoboslabs/illuminati/processor/infra/kafka/impl/KafkaInfraTemplateImpl.java
+++ b/illuminati/illuminati-processor/src/main/java/me/phoboslabs/illuminati/processor/infra/kafka/impl/KafkaInfraTemplateImpl.java
@@ -140,7 +140,7 @@ public class KafkaInfraTemplateImpl extends BasicTemplate implements IlluminatiI
             return false;
         }
 
-        boolean canIConnect = true;
+        int canIConnectCount = 0;
         try {
             List<String> clusterList = this.illuminatiProperties.getClusterArrayList();
             if (CollectionUtils.isNotEmpty(clusterList)) {
@@ -148,29 +148,27 @@ public class KafkaInfraTemplateImpl extends BasicTemplate implements IlluminatiI
                     final String[] clusterAddressInfo = clusterAddress.split(":");
                     if (clusterAddressInfo.length != 2) {
                         KAFKA_TEMPLATE_IMPL_LOGGER.error("check kafka cluster({}). maybe typo in cluster address string.", clusterAddress);
-                        canIConnect = false;
                     } else {
                         boolean connectResult = NetworkUtil.canIConnect(clusterAddressInfo[0], Integer.parseInt(clusterAddressInfo[1]));
-                        if (!connectResult) {
+                        if (connectResult) {
+                            canIConnectCount++;
+                        } else {
                             KAFKA_TEMPLATE_IMPL_LOGGER.error("check kafka cluster. connection error ({})", clusterAddress);
-                            canIConnect = false;
                         }
                     }
                 }
             } else {
                 KAFKA_TEMPLATE_IMPL_LOGGER.error("cluster address string is required value.");
-                canIConnect = false;
             }
         } catch (Exception ex) {
             KAFKA_TEMPLATE_IMPL_LOGGER.error("check kafka cluster.", ex);
-            canIConnect = false;
         }
 
-        if (!canIConnect) {
+        if (canIConnectCount == 0) {
             this.kafkaProducer.close();
         }
 
-        return canIConnect;
+        return canIConnectCount > 0;
     }
 
     @Override


### PR DESCRIPTION
### Related Issues
https://github.com/LeeKyoungIl/illuminati/issues/106

### Changes and Reasons
The Kafka works even if only one server is alive.
But now all Kafka servers(broker) must be running, so the illuminati work.

fix Even if only one is alive. work without problem.

### PR Point
<!-Please write what you would like the reviewers to focus on->

### Note
<!-Please write down any references. ->
none
